### PR TITLE
Implement Cache Versioning

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 allprojects {
-    version = "1.0.4"
+    version = "1.0.5"
     group = "gg.ingot"
 }
 

--- a/core/src/main/kotlin/gg/ingot/angostura/AngosturaSettings.kt
+++ b/core/src/main/kotlin/gg/ingot/angostura/AngosturaSettings.kt
@@ -16,7 +16,7 @@ data class AngosturaSettings(
     val defaultTTL: Duration? = null,
     val defaultRefreshTTL: Boolean = false,
     val serializationAdapter: AngosturaSerializationAdapter? = null,
-    var version: Int? = null
+    var version: String? = null
 ) {
     private val _extraSettings = mutableMapOf<KClass<*>, AngosturaExtraSettings>()
     val extraSettings: Map<KClass<*>, AngosturaExtraSettings>

--- a/core/src/main/kotlin/gg/ingot/angostura/AngosturaSettings.kt
+++ b/core/src/main/kotlin/gg/ingot/angostura/AngosturaSettings.kt
@@ -1,7 +1,6 @@
 package gg.ingot.angostura
 
 import gg.ingot.angostura.serialization.AngosturaSerializationAdapter
-import java.util.Properties
 import kotlin.reflect.KClass
 import kotlin.time.Duration
 
@@ -10,12 +9,14 @@ import kotlin.time.Duration
  * @param defaultTTL The default time-to-live for cache entries.
  * @param defaultRefreshTTL If the time-to-live should be refreshed when the data is accessed.
  * @param serializationAdapter The serialization adapter to use for the cache.
+ * @param version The version of the cache.
  * @since 1.0.0
  */
 data class AngosturaSettings(
     val defaultTTL: Duration? = null,
     val defaultRefreshTTL: Boolean = false,
-    val serializationAdapter: AngosturaSerializationAdapter? = null
+    val serializationAdapter: AngosturaSerializationAdapter? = null,
+    var version: Int? = null
 ) {
     private val _extraSettings = mutableMapOf<KClass<*>, AngosturaExtraSettings>()
     val extraSettings: Map<KClass<*>, AngosturaExtraSettings>

--- a/core/src/main/kotlin/gg/ingot/angostura/cache/KeyedCacheLayer.kt
+++ b/core/src/main/kotlin/gg/ingot/angostura/cache/KeyedCacheLayer.kt
@@ -8,13 +8,28 @@ import kotlin.time.Duration
  * `angostura:cache:account:<PROVIDED>`
  * @param T The type of the value to store.
  * @property key The key to store the value under.
+ * @property version The version of the cache.
  * @property ttl The time to live of the cached value.
  * @property refreshTTL If the time to live should be refreshed when the data is accessed.
  * @see CacheLayer
  * @since 1.0.0
  */
 abstract class KeyedCacheLayer<T : Any>(
-    protected val key: String,
+    private val key: String,
     ttl: Duration,
-    refreshTTL: Boolean = false
-) : CacheLayer<T>(ttl, refreshTTL)
+    refreshTTL: Boolean = false,
+    private val version: Int?
+) : CacheLayer<T>(ttl, refreshTTL) {
+    /**
+     * Build the key for the cache.
+     * @param str The identifier to build the key with.
+     * @return The built key.
+     */
+    protected fun buildKey(str: String): String {
+        return if (version != null) {
+            "$key:$version:$str"
+        } else {
+            "$key:$str"
+        }
+    }
+}

--- a/core/src/main/kotlin/gg/ingot/angostura/cache/KeyedCacheLayer.kt
+++ b/core/src/main/kotlin/gg/ingot/angostura/cache/KeyedCacheLayer.kt
@@ -18,7 +18,7 @@ abstract class KeyedCacheLayer<T : Any>(
     private val key: String,
     ttl: Duration,
     refreshTTL: Boolean = false,
-    private val version: Int?
+    private val version: String?
 ) : CacheLayer<T>(ttl, refreshTTL) {
     /**
      * Build the key for the cache.

--- a/jedis-extension/src/main/kotlin/gg/ingot/angostura/jedis/JedisCache.kt
+++ b/jedis-extension/src/main/kotlin/gg/ingot/angostura/jedis/JedisCache.kt
@@ -22,9 +22,10 @@ internal abstract class JedisCache<T : Any>(
     key: String,
     ttl: Duration,
     refreshTTL: Boolean = false,
+    version: Int?,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val kClass: KClass<*>
-) : KeyedCacheLayer<T>(key, ttl, refreshTTL) {
+) : KeyedCacheLayer<T>("${redisKey}:${key}", ttl, refreshTTL, version) {
     private val coroutineScope = CoroutineScope(dispatcher + SupervisorJob())
 
     /**
@@ -77,15 +78,6 @@ internal abstract class JedisCache<T : Any>(
     protected abstract fun jedis(): JedisWrapper
 
     /**
-     * Build the key for the cache.
-     * @param str The string to append to the key.
-     * @return The built key.
-     */
-    private fun buildKey(str: String): String {
-        return "${redisKey}:${key}:${str}"
-    }
-
-    /**
      * Jedis Wrapper to allow for either [JedisPool] or [JedisCluster].
      */
     protected interface JedisWrapper {
@@ -122,6 +114,7 @@ internal abstract class JedisCache<T : Any>(
  * @param refreshTTL If the time to live should be refreshed on access.
  * @param dispatcher The coroutine dispatcher.
  * @param kClass The class of the cache.
+ * @param arrayType The class of the array type.
  * @return The cache.
  */
 fun <T : Any> createJedisCache(
@@ -130,6 +123,7 @@ fun <T : Any> createJedisCache(
     key: String,
     ttl: Duration,
     refreshTTL: Boolean,
+    version: Int?,
     dispatcher: CoroutineDispatcher,
     kClass: KClass<*>,
     arrayType: KClass<*>? = null
@@ -139,18 +133,18 @@ fun <T : Any> createJedisCache(
     return if(kClass in CacheLayer.supportedPrimitiveTypes) {
         // primitive cache
         if(jedisSettings.pooled) {
-            JedisPoolCache(jedisSettings.redisKey, key, ttl, refreshTTL, jedisSettings.pool!!, dispatcher, kClass)
+            JedisPoolCache(jedisSettings.redisKey, key, ttl, refreshTTL, version, jedisSettings.pool!!, dispatcher, kClass)
         } else {
-            JedisClusterCache(jedisSettings.redisKey, key, ttl, refreshTTL, jedisSettings.cluster!!, dispatcher, kClass)
+            JedisClusterCache(jedisSettings.redisKey, key, ttl, refreshTTL, version, jedisSettings.cluster!!, dispatcher, kClass)
         }
     } else {
         // json cache
         checkNotNull(settings.serializationAdapter) { "no serialization adapter set in angostura settings." }
 
         if(jedisSettings.pooled) {
-            JedisPoolJsonCache(jedisSettings.redisKey, key, ttl, refreshTTL, jedisSettings.pool!!, dispatcher, kClass, arrayType, settings.serializationAdapter!!)
+            JedisPoolJsonCache(jedisSettings.redisKey, key, ttl, refreshTTL, version, jedisSettings.pool!!, dispatcher, kClass, arrayType, settings.serializationAdapter!!)
         } else {
-            JedisClusterJsonCache(jedisSettings.redisKey, key, ttl, refreshTTL, jedisSettings.cluster!!, dispatcher, kClass, arrayType, settings.serializationAdapter!!)
+            JedisClusterJsonCache(jedisSettings.redisKey, key, ttl, refreshTTL, version, jedisSettings.cluster!!, dispatcher, kClass, arrayType, settings.serializationAdapter!!)
         }
     }
 }
@@ -184,11 +178,21 @@ inline fun <reified T : Any> Angostura.jedisCache(
         key,
         ttl,
         refreshTTL,
+        settings.version,
         dispatcher,
         T::class
     )
 }
 
+/**
+ * Create a new jedis cache for collections.
+ * @param key The key for the cache.
+ * @param ttl The time to live of the cache.
+ * @param refreshTTL If the time to live should be refreshed on access.
+ * @param dispatcher The coroutine dispatcher.
+ * @return The cache.
+ * @throws IllegalStateException If [AngosturaJedisSettings] are not set.
+ */
 inline fun <reified T : Any> Angostura.jedisArrayCache(
     key: String? = T::class.java.simpleName,
     ttl: Duration? = settings.defaultTTL ?: error("no ttl specified and no default was set"),
@@ -205,6 +209,7 @@ inline fun <reified T : Any> Angostura.jedisArrayCache(
         key,
         ttl,
         refreshTTL,
+        settings.version,
         dispatcher,
         List::class,
         T::class

--- a/jedis-extension/src/main/kotlin/gg/ingot/angostura/jedis/JedisCache.kt
+++ b/jedis-extension/src/main/kotlin/gg/ingot/angostura/jedis/JedisCache.kt
@@ -22,7 +22,7 @@ internal abstract class JedisCache<T : Any>(
     key: String,
     ttl: Duration,
     refreshTTL: Boolean = false,
-    version: Int?,
+    version: String?,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val kClass: KClass<*>
 ) : KeyedCacheLayer<T>("${redisKey}:${key}", ttl, refreshTTL, version) {
@@ -123,7 +123,7 @@ fun <T : Any> createJedisCache(
     key: String,
     ttl: Duration,
     refreshTTL: Boolean,
-    version: Int?,
+    version: String?,
     dispatcher: CoroutineDispatcher,
     kClass: KClass<*>,
     arrayType: KClass<*>? = null

--- a/jedis-extension/src/main/kotlin/gg/ingot/angostura/jedis/JedisClusterCache.kt
+++ b/jedis-extension/src/main/kotlin/gg/ingot/angostura/jedis/JedisClusterCache.kt
@@ -12,10 +12,11 @@ internal open class JedisClusterCache<T : Any>(
     key: String,
     ttl: Duration,
     refreshTTL: Boolean = false,
+    version: Int?,
     private val jedisCluster: JedisCluster,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
     kClass: KClass<*>
-): JedisCache<T>(redisKey, key, ttl, refreshTTL, dispatcher, kClass) {
+): JedisCache<T>(redisKey, key, ttl, refreshTTL, version, dispatcher, kClass) {
     override fun jedis() = JedisClusterWrapper(jedisCluster)
 }
 
@@ -24,12 +25,13 @@ internal class JedisClusterJsonCache<T : Any>(
     key: String,
     ttl: Duration,
     refreshTTL: Boolean = false,
+    version: Int?,
     jedisCluster: JedisCluster,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val jsonKClass: KClass<*>,
     private val arrayType: KClass<*>? = null,
     private val serializationAdapter: AngosturaSerializationAdapter
-): JedisClusterCache<T>(redisKey, key, ttl, refreshTTL, jedisCluster, dispatcher, String::class) {
+): JedisClusterCache<T>(redisKey, key, ttl, refreshTTL, version, jedisCluster, dispatcher, String::class) {
     override suspend fun put(key: String, value: T): T {
         super.putString(key, serializationAdapter.serialize(value, jsonKClass, arrayType))
         return value

--- a/jedis-extension/src/main/kotlin/gg/ingot/angostura/jedis/JedisClusterCache.kt
+++ b/jedis-extension/src/main/kotlin/gg/ingot/angostura/jedis/JedisClusterCache.kt
@@ -12,7 +12,7 @@ internal open class JedisClusterCache<T : Any>(
     key: String,
     ttl: Duration,
     refreshTTL: Boolean = false,
-    version: Int?,
+    version: String?,
     private val jedisCluster: JedisCluster,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
     kClass: KClass<*>
@@ -25,7 +25,7 @@ internal class JedisClusterJsonCache<T : Any>(
     key: String,
     ttl: Duration,
     refreshTTL: Boolean = false,
-    version: Int?,
+    version: String?,
     jedisCluster: JedisCluster,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val jsonKClass: KClass<*>,

--- a/jedis-extension/src/main/kotlin/gg/ingot/angostura/jedis/JedisPoolCache.kt
+++ b/jedis-extension/src/main/kotlin/gg/ingot/angostura/jedis/JedisPoolCache.kt
@@ -12,7 +12,7 @@ internal open class JedisPoolCache<T : Any>(
     key: String,
     ttl: Duration,
     refreshTTL: Boolean = false,
-    version: Int?,
+    version: String?,
     private val jedisPool: JedisPool,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
     kClass: KClass<*>
@@ -25,7 +25,7 @@ internal class JedisPoolJsonCache<T : Any>(
     key: String,
     ttl: Duration,
     refreshTTL: Boolean = false,
-    version: Int?,
+    version: String?,
     jedisPool: JedisPool,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val jsonKClass: KClass<*>,

--- a/jedis-extension/src/main/kotlin/gg/ingot/angostura/jedis/JedisPoolCache.kt
+++ b/jedis-extension/src/main/kotlin/gg/ingot/angostura/jedis/JedisPoolCache.kt
@@ -12,10 +12,11 @@ internal open class JedisPoolCache<T : Any>(
     key: String,
     ttl: Duration,
     refreshTTL: Boolean = false,
+    version: Int?,
     private val jedisPool: JedisPool,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
     kClass: KClass<*>
-): JedisCache<T>(redisKey, key, ttl, refreshTTL, dispatcher, kClass) {
+): JedisCache<T>(redisKey, key, ttl, refreshTTL, version, dispatcher, kClass) {
     override fun jedis(): JedisWrapper = JedisPoolWrapper(jedisPool)
 }
 
@@ -24,12 +25,13 @@ internal class JedisPoolJsonCache<T : Any>(
     key: String,
     ttl: Duration,
     refreshTTL: Boolean = false,
+    version: Int?,
     jedisPool: JedisPool,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val jsonKClass: KClass<*>,
     private val arrayType: KClass<*>? = null,
     private val serializationAdapter: AngosturaSerializationAdapter
-): JedisPoolCache<T>(redisKey, key, ttl, refreshTTL, jedisPool, dispatcher, String::class) {
+): JedisPoolCache<T>(redisKey, key, ttl, refreshTTL, version, jedisPool, dispatcher, String::class) {
     override suspend fun put(key: String, value: T): T {
         super.putString(key, serializationAdapter.serialize(value, jsonKClass, arrayType))
         return value


### PR DESCRIPTION
Implementing versioned caches allows us to deploy back from a breaking build and allows us to have slower deployment rollouts without worrying about cache mismatches in data.